### PR TITLE
Allow PIN, Apple Watch or biometrics as screen lock methods

### DIFF
--- a/ios/Classes/DeviceSafetyInfoPlugin.swift
+++ b/ios/Classes/DeviceSafetyInfoPlugin.swift
@@ -30,7 +30,7 @@ public class DeviceSafetyInfoPlugin: NSObject, FlutterPlugin {
         case "isScreenLock":
             let context = LAContext()
             let isScreenLockEnabled = context.canEvaluatePolicy(
-                .deviceOwnerAuthenticationWithBiometrics, error: nil)
+                .deviceOwnerAuthentication, error: nil)
             result(isScreenLockEnabled)
         case "isVPNCheck":
             let isVPN = isVpnActive()


### PR DESCRIPTION
Previously only biometrics would work on iOS.